### PR TITLE
ci(#19): workflow to terminate environment

### DIFF
--- a/.github/workflows/terminate_environment.yaml
+++ b/.github/workflows/terminate_environment.yaml
@@ -1,0 +1,40 @@
+name: Terminate environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to terminate'
+        required: true
+        type: string
+        options:
+          - 'staging'
+          - 'production'
+
+jobs:
+  terminate:
+    name: Terminate environment
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    defaults:
+      run:
+        working-directory: deployment/production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: AWS CLI setup
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ">=1"
+      - name: Terraform init
+        run: |
+          echo '${{ secrets.TF_BACKEND }}' > backend.hcl
+          terraform init -backend-config=backend.hcl
+      - name: Terraform destroy
+        run: terraform destroy -auto-approve

--- a/deployment/production/ecs.tf
+++ b/deployment/production/ecs.tf
@@ -14,7 +14,7 @@ data "template_file" "backend" {
     app_backend_image               = var.app_backend_image
     app_backend_log_group           = var.app_backend_log_group
     app_backend_migration_log_group = "${var.app_backend_log_group}-migrate"
-    app_database_url                = local.app_database_url
+    app_database_url                = local.app_database_url # @fixme: value of this variable can be seen in the dashboard, it should be a secret
     ghcr_credentials_arn            = aws_secretsmanager_secret.ghcr_credentials.arn
   }
 }

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-changes = "backend/tsconfig.build.json readme.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a GitHub Actions workflow to allow users to terminate either the 'staging' or 'production' environment based on user input.

- **Refactor**
  - Updated the `app_database_url` variable assignment in the deployment configuration to include a comment about a security concern, ensuring its value should be kept secret in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->